### PR TITLE
Added instructions for installing UWP and other apps from the Microsoft Store

### DIFF
--- a/guides/windows.md
+++ b/guides/windows.md
@@ -44,7 +44,7 @@ Make sure you select **arm64** if you are on Apple Silicon and **amd64** if you 
 **WIP**
 1. Google the UWP apps (or any other apps available in the Microsoft Store) of interest to find its official download link from Microsoft.
     a. For example, if you wanted to download Windows Photo app, the following link is what you're looking for:
-        https://apps.microsoft.com/store/detail/microsoft-photos/9WZDNCRFJBH4?hl=en-us&gl=us
+    https://apps.microsoft.com/store/detail/microsoft-photos/9WZDNCRFJBH4?hl=en-us&gl=us
 2. Navigate to the [Online link generator for Microsoft Store](https://store.rg-adguard.net/), input your link in the searchbox, and click on the checkbox.
     a. The site will provide \*.appx dependencies needed for your app work.
 3. Download all the \*.appx files corresponding to your Windows architecture along with the .Msixbundle file associated with your app.

--- a/guides/windows.md
+++ b/guides/windows.md
@@ -44,7 +44,7 @@ Make sure you select **arm64** if you are on Apple Silicon and **amd64** if you 
 **WIP**
 1. Google the UWP apps (or any other apps available in the Microsoft Store) of interest to find its official download link from Microsoft.
     - For example, if you wanted to download Windows Photo app, the following link is what you're looking for:
-    https://apps.microsoft.com/store/detail/microsoft-photos/9WZDNCRFJBH4?hl=en-us&gl=us
+     - https://apps.microsoft.com/store/detail/microsoft-photos/9WZDNCRFJBH4?hl=en-us&gl=us
 2. Navigate to the [Online link generator for Microsoft Store](https://store.rg-adguard.net/), input your link in the searchbox, and click on the checkbox.
     - The site will provide \*.appx dependencies needed for your app work.
 3. Download all the \*.appx files corresponding to your Windows architecture along with the .Msixbundle file associated with your app.

--- a/guides/windows.md
+++ b/guides/windows.md
@@ -42,7 +42,26 @@ Make sure you select **arm64** if you are on Apple Silicon and **amd64** if you 
 
 {: .label .label-yellow }
 **WIP**
-
+1. Google the UWP apps (or any other apps available in the Microsoft Store) of interest to find its official download link from Microsoft.
+    a. For example, if you wanted to download Windows Photo app, the following link is what you're looking for:
+        https://apps.microsoft.com/store/detail/microsoft-photos/9WZDNCRFJBH4?hl=en-us&gl=us
+2. Navigate to the [Online link generator for Microsoft Store](https://store.rg-adguard.net/), input your link in the searchbox, and click on the checkbox.
+    a. The site will provide \*.appx dependencies needed for your app work.
+3. Download all the \*.appx files corresponding to your Windows architecture along with the .Msixbundle file associated with your app.
+    a. For example, if you want to install the Photos app on Windows 11 arm64, you would need to download these files:
+      -Microsoft.NET.Native.Framework...arm64...appx
+      -Microsoft.NET.Native.Runtime...arm64...appx
+      -Microsoft.Services.Store.Engagement...arm64...appx
+      -Microsoft.UI.Xaml.(2.0/2.1/2.2.4/2.7)...arm64...appx
+      -Microsoft.VCLibs.140.00.UWPDesktop...arm64...appx
+      -Microsoft.VCLibs.140.00...arm64...appx
+      -Microsoft.Windows.Photos...neutral...msixbundle
+4. Install .appx files with Windows PowerShell using the following command:
+    `Add-AppPackage -Path .\[Location of the downloaded .appx file].appx`
+5. After installing all the .appx dependencies, install the .Msixbundle using the same command.
+    `Add-AppPackage -Path .\[Location of the downloaded .Msixbundle file].Msixbundle`
+    
+The app should be functional after completing the aforementioned steps. 
 Check [this issue](https://github.com/utmapp/UTM/issues/3884) for more information.
 
 ## Troubleshooting

--- a/guides/windows.md
+++ b/guides/windows.md
@@ -39,14 +39,13 @@ Make sure you select **arm64** if you are on Apple Silicon and **amd64** if you 
 10. Follow the Windows installer. If you have issues with the mouse, press the mouse capture button in the toolbar to send mouse input directly. Press Control+Option together to exit mouse capture mode. Sometimes, due to driver issues, you can enter and exit capture mode and the mouse cursor works normally again.
 
 ### Installing the Microsoft Store and UWP apps (optional)
-
 {: .label .label-yellow }
 **WIP**
 1. Google the UWP apps (or any other apps available in the Microsoft Store) of interest to find its official download link from Microsoft.
     - For example, if you wanted to download Windows Photo app, the following link is what you're looking for:
         - https://apps.microsoft.com/store/detail/microsoft-photos/9WZDNCRFJBH4?hl=en-us&gl=us
 2. Navigate to the [Online link generator for Microsoft Store](https://store.rg-adguard.net/), input your link in the searchbox, and click on the checkbox.
-    - The site will provide \*.appx dependencies needed for your app work.
+    - The site will provide \*.appx dependencies needed for your to app work.
 3. Download all the \*.appx files corresponding to your Windows architecture along with the .Msixbundle file associated with your app.
     - For example, if you want to install the Photos app on Windows 11 arm64, you would need to download these files:
       - Microsoft.NET.Native.Framework...arm64...appx

--- a/guides/windows.md
+++ b/guides/windows.md
@@ -43,12 +43,12 @@ Make sure you select **arm64** if you are on Apple Silicon and **amd64** if you 
 {: .label .label-yellow }
 **WIP**
 1. Google the UWP apps (or any other apps available in the Microsoft Store) of interest to find its official download link from Microsoft.
-    a. For example, if you wanted to download Windows Photo app, the following link is what you're looking for:
+    - For example, if you wanted to download Windows Photo app, the following link is what you're looking for:
     https://apps.microsoft.com/store/detail/microsoft-photos/9WZDNCRFJBH4?hl=en-us&gl=us
 2. Navigate to the [Online link generator for Microsoft Store](https://store.rg-adguard.net/), input your link in the searchbox, and click on the checkbox.
-    a. The site will provide \*.appx dependencies needed for your app work.
+    - The site will provide \*.appx dependencies needed for your app work.
 3. Download all the \*.appx files corresponding to your Windows architecture along with the .Msixbundle file associated with your app.
-    a. For example, if you want to install the Photos app on Windows 11 arm64, you would need to download these files:
+    - For example, if you want to install the Photos app on Windows 11 arm64, you would need to download these files:
       -Microsoft.NET.Native.Framework...arm64...appx
       -Microsoft.NET.Native.Runtime...arm64...appx
       -Microsoft.Services.Store.Engagement...arm64...appx

--- a/guides/windows.md
+++ b/guides/windows.md
@@ -44,22 +44,26 @@ Make sure you select **arm64** if you are on Apple Silicon and **amd64** if you 
 **WIP**
 1. Google the UWP apps (or any other apps available in the Microsoft Store) of interest to find its official download link from Microsoft.
     - For example, if you wanted to download Windows Photo app, the following link is what you're looking for:
-     - https://apps.microsoft.com/store/detail/microsoft-photos/9WZDNCRFJBH4?hl=en-us&gl=us
+        - https://apps.microsoft.com/store/detail/microsoft-photos/9WZDNCRFJBH4?hl=en-us&gl=us
 2. Navigate to the [Online link generator for Microsoft Store](https://store.rg-adguard.net/), input your link in the searchbox, and click on the checkbox.
     - The site will provide \*.appx dependencies needed for your app work.
 3. Download all the \*.appx files corresponding to your Windows architecture along with the .Msixbundle file associated with your app.
     - For example, if you want to install the Photos app on Windows 11 arm64, you would need to download these files:
-      -Microsoft.NET.Native.Framework...arm64...appx
-      -Microsoft.NET.Native.Runtime...arm64...appx
-      -Microsoft.Services.Store.Engagement...arm64...appx
-      -Microsoft.UI.Xaml.(2.0/2.1/2.2.4/2.7)...arm64...appx
-      -Microsoft.VCLibs.140.00.UWPDesktop...arm64...appx
-      -Microsoft.VCLibs.140.00...arm64...appx
-      -Microsoft.Windows.Photos...neutral...msixbundle
+      - Microsoft.NET.Native.Framework...arm64...appx
+      - Microsoft.NET.Native.Runtime...arm64...appx
+      - Microsoft.Services.Store.Engagement...arm64...appx
+      - Microsoft.UI.Xaml.(2.0/2.1/2.2.4/2.7)...arm64...appx
+      - Microsoft.VCLibs.140.00.UWPDesktop...arm64...appx
+      - Microsoft.VCLibs.140.00...arm64...appx
+      - Microsoft.Windows.Photos...neutral...msixbundle
 4. Install .appx files with Windows PowerShell using the following command:
-    `Add-AppPackage -Path .\[Location of the downloaded .appx file].appx`
+```
+Add-AppPackage -Path .\[Location of the downloaded .appx file].appx
+```
 5. After installing all the .appx dependencies, install the .Msixbundle using the same command.
-    `Add-AppPackage -Path .\[Location of the downloaded .Msixbundle file].Msixbundle`
+```
+Add-AppPackage -Path .\[Location of the downloaded .Msixbundle file].Msixbundle
+```
     
 The app should be functional after completing the aforementioned steps. 
 Check [this issue](https://github.com/utmapp/UTM/issues/3884) for more information.


### PR DESCRIPTION
In the case of the Microsoft Store not working or not being able to install a particular UWP app on newly installed Windows, this method extract and install the app's dependencies manually, allowing for the installation UWP and other Microsoft Store apps.