### PR TITLE
Fix small typo in the documentation for macOS guest support

### DIFF
--- a/guest-support/macos.md
+++ b/guest-support/macos.md
@@ -17,7 +17,7 @@ In the [new VM wizard]({% link basics/basics.md %}), select "Virtualization" and
 Apple distributes macOS software in an IPSW file. UTM can download the latest compatible macOS automatically if you do not select an IPSW. You can also download IPSWs from a third party site such as [ipsw.me](https://ipsw.me/VirtualMac2,1).
 
 {: .warning }
-We do not attest to the safety, validity, or compatibility of IPSws downloaded from third party sites such as ipsw.me. We recommend using UTM's automatic download of the most compatible IPSW.
+We do not attest to the safety, validity, or compatibility of IPSWs downloaded from third party sites such as ipsw.me. We recommend using UTM's automatic download of the most compatible IPSW.
 
 ## Shared Directories
 


### PR DESCRIPTION
Pretty self-explanatory, this PR fixes one small typo in the documentation for macOS guest support

Also, I noticed that `.label`s are broken in the docs preview, ~~submitting a PR to [theme's upstream](https://github.com/just-the-docs/just-the-docs) soon~~ PR here: https://github.com/just-the-docs/just-the-docs/pull/1104. Perhaps that dependency should be managed by `bundle` and version pinned? 