### PR TITLE
use minacle's chntpw fork

### DIFF
--- a/guides/windows.md
+++ b/guides/windows.md
@@ -65,8 +65,8 @@ Make sure you have the prerequisites installed
 
 ```
 $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-$ brew tap sidneys/homebrew
-$ brew install aria2 cabextract wimlib cdrtools sidneys/homebrew/chntpw
+$ brew tap minacle/chntpw
+$ brew install aria2 cabextract wimlib cdrtools minacle/chntpw/chntpw
 ```
 
 Then you can run `uup_download_macos.sh`


### PR DESCRIPTION
The current one has an issue with failing tests (`make test`) which causes the installation to never succeed to use UUP.

```
==> Installing chntpw from sidneys/homebrew
==> Installing dependencies for sidneys/homebrew/chntpw: sidneys/homebrew/openssl@1.0
==> Installing sidneys/homebrew/chntpw dependency: sidneys/homebrew/openssl@1.0
==> Patching
==> Applying openssl-1.0.2u-darwin-arm64.patch
patching file Configure
==> perl ./Configure --prefix=/opt/homebrew/Cellar/openssl@1.0/1.0.2u_1 --openssldir=/opt/homebrew/etc/openssl@1.0 no-ssl2 no-ssl3 no-zlib shared enable-cms darwin64-arm64-cc enable-ec_nistp_64_gcc_128
==> make
==> make test
Last 15 lines from /Users/adm-terezipyrope/Library/Logs/Homebrew/openssl@1.0/03.make:
8039226348:error:100B906B:elliptic curve routines:EC_POINT_set_affine_coordinates_GF2m:point is not on curve:ec_lib.c:994:
8039226348:error:100B906B:elliptic curve routines:EC_POINT_set_affine_coordinates_GF2m:point is not on curve:ec_lib.c:994:
8039226348:error:100B906B:elliptic curve routines:EC_POINT_set_affine_coordinates_GF2m:point is not on curve:ec_lib.c:994:
8039226348:error:100B906B:elliptic curve routines:EC_POINT_set_affine_coordinates_GF2m:point is not on curve:ec_lib.c:994:
8039226348:error:100B906B:elliptic curve routines:EC_POINT_set_affine_coordinates_GF2m:point is not on curve:ec_lib.c:994:
8039226348:error:100B906B:elliptic curve routines:EC_POINT_set_affine_coordinates_GF2m:point is not on curve:ec_lib.c:994:
8039226348:error:100B906B:elliptic curve routines:EC_POINT_set_affine_coordinates_GF2m:point is not on curve:ec_lib.c:994:
8039226348:error:100B906B:elliptic curve routines:EC_POINT_set_affine_coordinates_GF2m:point is not on curve:ec_lib.c:994:
8039226348:error:100B906B:elliptic curve routines:EC_POINT_set_affine_coordinates_GF2m:point is not on curve:ec_lib.c:994:
8039226348:error:100B906B:elliptic curve routines:EC_POINT_set_affine_coordinates_GF2m:point is not on curve:ec_lib.c:994:
8039226348:error:1007C06B:elliptic curve routines:EC_POINT_set_affine_coordinates_GFp:point is not on curve:ec_lib.c:968:
8039226348:error:1007C06B:elliptic curve routines:EC_POINT_set_affine_coordinates_GFp:point is not on curve:ec_lib.c:968:
8039226348:error:1007C06B:elliptic curve routines:EC_POINT_set_affine_coordinates_GFp:point is not on curve:ec_lib.c:968:
make[1]: *** [test_ec] Error 1
make: *** [tests] Error 2

If reporting this issue please do so at (not Homebrew/brew or Homebrew/homebrew-core):
  https://github.com/sidneys/homebrew-homebrew/issues

These open issues may also help:
Mac M1 chntpw not building (Openssl 1.0 requirement not satisfied) https://github.com/sidneys/homebrew-homebrew/issues/2
```

minacle's tap https://github.com/sidneys/homebrew-homebrew/issues/2#issuecomment-885728072 appears to have this fixed and it's unclear if the developer will fix this at the moment. Multiple people in the same issue and https://github.com/sidneys/homebrew-homebrew/issues/16 are reporting the same problem.