### PR TITLE
Add `davfs2` instructions to mount shared WebDAV directory in Linux

### DIFF
--- a/guest-support/linux.md
+++ b/guest-support/linux.md
@@ -92,6 +92,43 @@ $ sudo yum install spice-webdavd
 $ sudo pacman -S phodav
 ```
 
+### Mount via `davfs2`
+
+Once you can verify WebDAV runs via `curl http://127.0.0.1:9843` you could use `davfs2` to mount the shared directory. 
+
+Mount it via `sudo mkdir /media/dav; sudo mount -t davfs -o noexec http://127.0.0.1:9843 /media/dav/`.
+
+To enable auto-mounting and/or mounting without root, add your user to the `davfs2` group: 
+
+```
+sudo usermod -a -G davfs2 $USER
+```
+
+Relog to apply the changes.
+
+Write a local davfs2 config at `$HOME/.davfs2/davfs2.conf`:
+
+```
+secrets               ~/.davfs2/secrets
+```
+
+And your secrets at `$HOME/.davfs2/secrets`:
+
+```
+127.0.0.1:9843        guest-username       guest-password
+/media/dav            host-username        host-password
+```
+
+And add this entry to `/etc/fstab`:
+
+```
+http://127.0.0.1:9843 /media/dav davfs noauto,user 0 0
+```
+
+Protect files with `sudo chmod 0700 $HOME/.davfs2/cache && sudo chmod 600 $HOME/.davfs2/secrets`. Then you can verify mounting without sudo via `mount /media/dav` and it should connect without prompt. 
+
+Now replace `noauto` with `auto` within the new `/etc/fstab` entry to enable auto-mounting at boot.
+
 ## VirtFS
 VirtFS enables [QEMU directory sharing]({% link settings-qemu/sharing.md %}#virtfs) as an alternative to SPICE WebDAV.
 


### PR DESCRIPTION
Instructions explain the bare minimum steps to auto mount a WebDAV network drive on boot that is hosted by `spice-vdagent`.

-----

I still have one problem with this, though. `mount -a` will mount the shared WebDAV, but it's very slow (30 seconds or more). Also, no matter which fstab options I test, it will not attempt to wait for it to connect when booting, it will cancel immediately.

During boot I see:

<img width="355" alt="[FAILED] Failed to mount /media/dav. SEE 'systemctl status media-dav.mount for details. [DEPEND] Dependency failed for Remote File Systems." src="https://github.com/utmapp/docs.getutm.app/assets/24259245/0397e05a-3d6f-4420-a42c-e49708b9bc4e">

After boot `systemctl status media-dav.mount` returns:

```
× media-dav.mount - /media/dav
     Loaded: loaded (/etc/fstab; generated)
     Active: failed (Result: exit-code) since Mon 2023-05-22 09:22:52 UTC; 18s ago
      Where: /media/dav
       What: http://127.0.0.1:9843
       Docs: man:fstab(5)
             man:systemd-fstab-generator(8)
        CPU: 30ms

May 22 09:22:52 ubuntu-server systemd[1]: Mounting /media/dav...
May 22 09:22:52 ubuntu-server mount.davfs[843]: davfs2 1.6.1
May 22 09:22:52 ubuntu-server systemd[1]: media-dav.mount: Mount process exited, code=exited, status=255/EXCEPTION
May 22 09:22:52 ubuntu-server systemd[1]: media-dav.mount: Failed with result 'exit-code'.
May 22 09:22:52 ubuntu-server systemd[1]: Failed to mount /media/dav.
```

Testing with `/etc/fstab`:

```
http://127.0.0.1:9843 /media/dav davfs user,rw,nolock,auto,_netdev,delay_connect 0 0
```

After manually running `mount -a`, `systemctl status media-dav.mount` returns:

```
● media-dav.mount - /media/dav
     Loaded: loaded (/etc/fstab; generated)
     Active: active (mounted) since Mon 2023-05-22 09:25:01 UTC; 31s ago
      Where: /media/dav
       What: http://127.0.0.1:9843
       Docs: man:fstab(5)
             man:systemd-fstab-generator(8)
        CPU: 30ms
```

So it should work, but it does not. I think `spice-webdavd` is too slow, I wonder how I can wait for it to be ready?

These instructions are not ready to be contributed. Any help is appreciated. For instance a working fstab configuration to load the shared WebDAV drive.