### PR TITLE
change UTM-HV and UTM-SE links to work again

### DIFF
--- a/installation/ios.md
+++ b/installation/ios.md
@@ -54,7 +54,7 @@ UTM SE does not support JIT (will run much slower) but is compatible with all si
 
 ## TrollStore
 
-If your device runs [TrollStore][11], then UTM can support additional features such as USB sharing and virtualization (currently limited to M1 iPads). You can install via TrollStore by downloading the TrollStore compatible IPA (UTM.HV.ipa) on your device and opening it with TrollStore.
+If your device runs [TrollStore][11], then UTM can support additional features such as USB sharing and virtualization (currently limited to M1 iPads). You can install via TrollStore by downloading the TrollStore compatible IPA (UTM-HV.ipa) on your device and opening it with TrollStore.
 
 {: .note }
 You cannot install the normal IPA (UTM.ipa) because it includes the `dynamic-codesigning` entitlements which TrollStore does not support.
@@ -72,8 +72,8 @@ UTM requires AppSync Unified which can be found on [Karen's Repo][8]. You need t
 |------|------------|--------------|-----|-----------|-----|
 | [UTM.deb](https://github.com/utmapp/UTM/releases/latest/download/UTM.deb) | Jailbroken iOS version | Open in Cydia, dpkg, or Sileo | Yes | Yes(1) | Yes |
 | [UTM.ipa](https://github.com/utmapp/UTM/releases/latest/download/UTM.ipa) | Non-jailbroken iOS version (sideloading) | AltStore, etc (see guide) | Yes(2) | No | No |
-| [UTM.HV.ipa](https://github.com/utmapp/UTM/releases/latest/download/UTM.HV.ipa) | Non-jailbroken iOS version (TrollStore) | TrollStore | Yes | Yes(1) | Yes |
-| [UTM.SE.ipa](https://github.com/utmapp/UTM/releases/latest/download/UTM.SE.ipa) | Non-jailbroken iOS version (sideloading) | AltStore, enterprise signing, etc | No | No | No |
+| [UTM-HV.ipa](https://github.com/utmapp/UTM/releases/latest/download/UTM-HV.ipa) | Non-jailbroken iOS version (TrollStore) | TrollStore | Yes | Yes(1) | Yes |
+| [UTM-SE.ipa](https://github.com/utmapp/UTM/releases/latest/download/UTM-SE.ipa) | Non-jailbroken iOS version (sideloading) | AltStore, enterprise signing, etc | No | No | No |
 
 1. Hypervisor on iOS requires an M1 iPad.
 2. Enabling JIT may require a separate JIT enabler such as [Jitterbug][9] or [Jitstreamer][10].


### PR DESCRIPTION
they seem to have dashes now, so the old links weren't working