### PR TITLE
Clarify the instruction on setting up VirtFS (fixing permission errors)

### DIFF
--- a/guest-support/linux.md
+++ b/guest-support/linux.md
@@ -95,36 +95,68 @@ $ sudo pacman -S phodav
 ## VirtFS
 VirtFS enables [QEMU directory sharing]({% link settings-qemu/sharing.md %}#virtfs) as an alternative to SPICE WebDAV.
 
-After making sure your Linux installation [supports 9pfs](#drivers), you can mount the share with the following command:
+After making sure your Linux installation [supports 9pfs](#drivers), you can automatically mount the share by adding the following entry to your `/etc/fstab`:
 
 ```
-$ sudo mkdir [mount point]
-$ sudo mount -t 9p -o trans=virtio share [mount point] -oversion=9p2000.L
+# UTM Shared Folder
+share /mnt/utm 9p trans=virtio,version=9p2000.L,rw,_netdev,nofail,auto 0 0
 ```
 
-Where `[mount point]` is the desired destination path. For example: `/media/share`.
+_Note_: `share` is the name UTM uses for the VirtIO device and you should not change it. You can replace `/mnt/utm` with a different folder if you like.
 
-You can also modify `/etc/fstab` and add the following line to automatically mount the share on startup:
+After updating `/etc/fstab` you need to create an empty folder for the mount:
 
+```sh
+sudo mkdir /mnt/utm
 ```
-share	[mount point]	9p	trans=virtio,version=9p2000.L,rw,_netdev,nofail	0	0
+
+You can apply the changes to `/etc/fstab` with the following commands (this will automatically happen on reboot as well):
+
+```sh
+systemctl daemon-reload
+systemctl restart network-fs.target
+systemctl list-units --type=mount
 ```
+
+A systemd `.mount` unit for `/mnt/utm` should now be displayed in the list, and you can access the contents of your shared folder.
 
 ### Fixing permission errors
-You may notice that accessing the mount point fails with "access denied" unless you're the root user. This is because by default the directory inherits the UID/GID from macOS/iOS which has a different numbering scheme. You can fix the error with the following command:
+You may notice that accessing the mount point fails with "access denied" unless you're the root user. This is because by default the directory inherits the UID/GID from macOS/iOS which has a different numbering scheme.
+
+To fix this we are going to use [`bindfs`](https://bindfs.org/) to create a mount in the user's home directory that we can access normally. You have to first install `bindfs` with your system's package manager.
+
+The first step is to get the UID and GID used by the host:
 
 ```
-$ sudo chown -R $USER [mount point]
+$ ls -na /mnt/utm
+total 8
+drwxr-xr-x 4 502 20  128 Feb 22 15:52 .
+drwxr-xr-x 3   0  0 4096 Feb 22 14:50 ..
+-rw-r--r-- 1 502 20   13 Feb 22 15:52 shared-file.txt
 ```
 
-This will not change the permissions on your host system but will store the guest ownership in a file attribute.
+In this case the UID for the host is `502` and the GID is `20`. You have to do the same for the guest user (usually UID `1000` and GID `1000`). Additionally, create an empty folder for the `bindfs` mount in the home directory:
 
-Alternatively, you can install `bindfs` and use the following `/etc/fstab` instead:
+```sh
+mkdir /home/user/utm
+```
+
+_Note_: In this example the username is `user`, you might have to adjust this to match your configuration.
+
+Now add another entry to `/etc/fstab`:
 
 ```
-share	/mnt/macos	9p	trans=virtio,version=9p2000.L,rw,_netdev,nofail	0	0
-/mnt/macos    [mount point] fuse.bindfs map=501/1000:@20/@1000,x-systemd.requires=/mnt/macos 0 0
+# bindfs mount to remap UID/GID
+/mnt/utm /home/user/utm fuse.bindfs map=502/1000:@20/@1000,x-systemd.requires=/mnt/utm,_netdev,nofail,auto 0 0
 ```
+
+An alternative solution is to recursively change the permissions of the files in your shared folder:
+
+```
+$ sudo chown -R $USER /mnt/utm
+```
+
+_Note_: This will not change the permissions on your host system, but it will add a custom `user.virtfs` file attributes to every file to store the guest ownership. It is not recommended to do this if you want to share your host's home folder for instance.
 
 ## **macOS**{: .label .label-green } VirtioFS
 When using Apple Virtualization backend, [directory sharing]({% link settings-apple/sharing.md %}) is enabled through VirtioFS.


### PR DESCRIPTION
The current instructions are rather unclear and the solution suggested for fixing the permission errors doesn't really work properly. The proper solution with `bindfs` isn't really explained clearly, so I improved the guide.