### PR TITLE
Update ubuntu.md to mitigate possilbe ARM64 issue with installing desktop package on server

### DIFF
--- a/guides/ubuntu.md
+++ b/guides/ubuntu.md
@@ -34,6 +34,17 @@ $ sudo apt update
 $ sudo apt install ubuntu-desktop
 $ sudo reboot
 ```
+On ARM64 it has been reported that doing this may enable two wait services: NetworkManager-wait-online.service and systemd-networkd-wait-online.service that causes a black screen at boot.
+To verify the fix is needed one can run:
+
+```bash
+systemctl is-enabled NetworkManager-wait-online.service systemd-networkd-wait-online.service
+```
+
+If you see two lines showing 'enabled' instead of one, the one that should be disabled can be done like:
+```bash
+systemctl disable systemd-networkd.service
+```
 
 ## Enable clipboard and directory sharing
 


### PR DESCRIPTION
Workaround for possible issue on ARM64 when installing ubuntu-desktop package after server installation with NetworkManager .

Credits:

https://askubuntu.com/questions/1217252/boot-process-hangs-at-systemd-networkd-wait-online/1501504#1501504
and
https://www.reddit.com/r/Ubuntu/comments/1cgmgx8/for_anyone_running_ubuntu_2404_through_qemu_vm_on/

other option is to download from : https://cdimage.ubuntu.com/noble/daily-live/20241025/