### PR TITLE
Updating support for macOS clipboard sharing

### DIFF
--- a/guest-support/sharing/clipboard.md
+++ b/guest-support/sharing/clipboard.md
@@ -8,7 +8,7 @@ grand_parent: Guest Support
 
 Clipboard sharing allows the guest and host to share clipboard contents. It is supported by the QEMU backend.
 
-**macOS 13+**{: .label .label-green } Clipboard sharing is now supported for Linux guests running on the Apple backend. There is still no support for macOS guests.
+**macOS 15+**{: .label .label-green } Clipboard sharing is now supported for Linux and macOS (15+) guests running on the Apple backend. 
 
 ## Enabling Clipboard Sharing
 


### PR DESCRIPTION
There is now support for clipboard sharing on macOS 15+, this was updated here

https://docs.getutm.app/guest-support/macos/#clipboard-sharing

But was not updated here...

https://docs.getutm.app/guest-support/sharing/clipboard/

So this PR fixes that.