### PR TITLE
Update windows.md - Windows 11 25H2 storage requirements

### DIFF
--- a/guides/windows.md
+++ b/guides/windows.md
@@ -32,7 +32,7 @@ Note that regardless of how you obtain the Windows installer, you must have a va
 4. Select "Windows".
 5. Pick the amount of RAM and CPU cores you wish to give access to the VM. Press "Continue".
 6. Make "Install Windows 10 or higher" is *checked*. Also make sure "Install drivers and SPICE tools" is *checked*. Press "Browse" and select the ISO you built in step 1.
-7. Specify the maximum amount of drive space to allocate. Press "Continue".
+7. Specify the maximum amount of drive space to allocate (*must be >64GB as of 25H2 or install will fail*). Press "Continue".
 8. If you have a directory you want to mount in the VM, you can select it here. Alternatively, you can skip this and select the directory later from the VM window's toolbar. The shared directory will be available after installing SPICE tools (see below). Press "Continue".
 9. Press "Save" to create the VM. Wait for the guest tools to finish downloading and press the Run button to start the VM.
 10. Press any key to start the Windows installer and follow the instructions on screen. If you have issues with the mouse, press the mouse capture button in the toolbar to send mouse input directly. Press Control+Option together to exit mouse capture mode. Sometimes, due to driver issues, you can enter and exit capture mode and the mouse cursor works normally again.


### PR DESCRIPTION
Storage requirements - 25H2 will fail to install unless the maximum disk image size is >64GB.
There are ways around this, but for the purposes of a quick start guide, a new user should be provided with working directions that allow them to install the OS without troubleshooting or implementing workarounds.